### PR TITLE
SM: fix to grab always recent windows_ami of Windows Server 1809 by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,10 @@ provider "aws" {}
 
 data "aws_ami" "windows_ami" {
   owners = ["amazon"]
-
+  most_recent = true
   filter {
     name   = "name"
-    values = ["Windows_Server-1809-English-Core-ContainersLatest-2019.09.11"]
+    values = ["Windows_Server-1809-English-Core-ContainersLatest-*"]
   }
 }
 


### PR DESCRIPTION
@fatz , @sebbrandt87 , please review hotfix since AWS removed image "Windows_Server-1809-English-Core-ContainersLatest-2019.09.11"